### PR TITLE
fix: replaced get_all with compatible method for CaseInsensitiveDict …

### DIFF
--- a/wvs/scanner/modules/a02_crypto.py
+++ b/wvs/scanner/modules/a02_crypto.py
@@ -126,7 +126,7 @@ def _check_cookies(target_url: str) -> List[Issue]:
         # requests' cookiejar API is clunky; iterate manually over headers instead
         pass
 
-    for hdr in resp.headers.get_all("Set-Cookie", default=[]):  # Python 3.11+ get_all()
+    for hdr in resp.headers.get_all("Set-Cookie"):  # Python 3.11+ get_all()
         # Normalise attributes for search
         attr = hdr.lower()
         if "secure" not in attr:


### PR DESCRIPTION
Bug gefixt: get_all gibt’s bei requests-Headern nicht

Hab gemerkt, dass ich auf den Response-Header mit get_all zugreifen wollte – das klappt aber bei dem CaseInsensitiveDict von requests nicht. Stattdessen jetzt nen passenden Zugriff benutzt, damit’s nicht mehr crasht.
